### PR TITLE
feat(api): implement database migration system for all DBMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ mongodb/data
 .vscode/
 *.swp
 *.swo
+*.env
+*.env.local
+*.env.*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+lya (Localise Your Application) is an open-source translation management platform. Monorepo with two workspaces: `api/` (NestJS + TypeORM) and `ui/` (React + Vite). No root package.json — each workspace is independent.
+
+## Common Commands
+
+### API (`api/` directory)
+```bash
+pnpm install              # Install dependencies
+pnpm start:dev            # Start dev server with watch mode (port 3000)
+pnpm build                # Build for production
+pnpm test                 # Run unit tests (Jest)
+pnpm test -- --testPathPattern=users  # Run tests for a specific module
+pnpm test:watch           # Run tests in watch mode
+pnpm test:e2e             # Run E2E tests (requires DB)
+pnpm lint                 # Lint (ESLint v9 flat config)
+pnpm lint:fix             # Lint and auto-fix
+pnpm format               # Format with Prettier
+```
+
+### UI (`ui/` directory)
+```bash
+pnpm install              # Install dependencies
+pnpm dev                  # Start Vite dev server (port 5173)
+pnpm build                # TypeScript check + Vite build
+pnpm lint                 # Lint
+pnpm lint:fix             # Lint and auto-fix
+pnpm format               # Format with Prettier
+```
+
+### Docker Workflow (requires go-task — https://taskfile.dev)
+```bash
+task up:postgres          # Start full stack with PostgreSQL
+task up:sqlite            # Start with SQLite (no DB container)
+task up:<db>              # db = postgres | mysql | mariadb | mongodb | sqlite
+task stop                 # Stop current DB stack
+task api:shell            # Shell into API container
+task api:lint             # Lint API from host
+task api:format           # Format API from host
+```
+
+## Architecture
+
+### Multi-Database Support (critical)
+
+The API supports 5 databases (PostgreSQL, MySQL, MariaDB, MongoDB, SQLite), one active at a time via `LYA_DB_TYPE`.
+
+**Key constraint:** `main.ts` loads `.env.database` via `dotenv` **before any module imports** because TypeORM decorators execute at import time. The `@UnifiedId()` decorator reads `LYA_DB_TYPE` at decoration time to apply `@ObjectIdColumn()` (MongoDB) or `@PrimaryGeneratedColumn()` (SQL).
+
+All entities extend `BaseEntity` (id, createdAt, updatedAt). All repositories extend `BaseRepository<T>` — always use `findById(id: string)` for lookups, never raw `findOne` with string IDs.
+
+### CQRS Pattern
+
+Every API resource uses `@nestjs/cqrs`. Write operations are Commands, reads are Queries. Controllers inject `CommandBus`/`QueryBus` and dispatch via `.execute()`.
+
+**Critical convention:** Handlers return `null` on not-found — controllers throw `NotFoundException`. Never throw from handlers.
+
+Handler arrays are exported from `commands/handlers/index.ts` and `queries/handlers/index.ts`, then spread into module providers.
+
+### Module Layout
+```
+api/src/<resource>/
+  <resource>.module.ts          # TypeOrmModule.forFeature([Entity]), CqrsModule
+  <resource>.controller.ts      # @ApiTags, @ApiOperation on every method
+  dto/create-<resource>.dto.ts  # class-validator + @ApiProperty()
+  entities/<resource>.entity.ts # Extends BaseEntity
+  commands/                     # Command classes + handlers/
+  queries/                      # Query classes + handlers/
+  repositories/<resource>.repository.ts  # Extends BaseRepository<T>
+```
+
+### Migrations
+
+Per-database migration directories in `api/src/migrations/{postgres,mysql,mariadb,mongodb,sqlite}/` — each DB gets its own migrations because TypeORM generates DB-specific SQL. MongoDB migrations are hand-written (schema-less, no auto-generation).
+
+Key commands (run inside `api/` or via Docker):
+```bash
+pnpm migration:generate src/migrations/<db>/Name  # Generate from entity diff (SQL DBs)
+pnpm migration:create src/migrations/mongodb/Name  # Scaffold empty migration (MongoDB)
+pnpm migration:run                                  # Apply pending migrations
+pnpm migration:revert                               # Revert last migration
+pnpm migration:show                                 # Show migration status
+```
+
+Taskfile equivalents: `task migration:generate NAME=Foo`, `task migration:run`, etc.
+
+In production, `migrationsRun: true` auto-applies pending migrations on app startup. In development, `synchronize: true` handles schema changes. See `api/MIGRATIONS.md` for full documentation.
+
+### Docker Compose Layering
+
+`compose.yml` (core services) + `compose.override.yml` (dev bind mounts) + per-DB file (`compose.postgres.yml`, etc.). Nginx reverse proxy routes `/api/` → API:3000, `/` → UI:5173.
+
+### UI
+
+React 19 + Vite + TypeScript. Early stage — single landing page, no routing/state management/API client yet. CSS Modules with BEM-like naming.
+
+## Code Conventions
+
+- **Package manager:** pnpm 10+, Node 20+
+- **No semicolons**, single quotes, 120 char print width (Prettier)
+- **Import order** enforced by ESLint: builtin → external → internal → parent → sibling → index, alphabetized
+- **DTOs:** class-validator decorators + `@ApiProperty()` on every field. Use `PartialType` from `@nestjs/swagger` for update DTOs
+- **Swagger:** `@ApiOperation({ summary })` on every controller method, `@ApiTags` on controllers
+- **Validation:** Global `ValidationPipe({ whitelist: true, transform: true })` in main.ts
+- **Testing:** Unit tests co-located as `*.spec.ts`. E2E in `api/test/`. Controllers mock CommandBus/QueryBus; handlers mock repositories

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,3 +107,35 @@ tasks:
     cmds:
       - task: api:format
       - task: ui:format
+
+  # Migration Tasks
+  migration:generate:
+    desc: Generate a migration for the active DB (NAME=MigrationName)
+    requires:
+      vars: [NAME]
+    cmds:
+      - task: api:migration:generate
+        vars: { NAME: "{{.NAME}}" }
+
+  migration:create:
+    desc: Create an empty migration for the active DB (NAME=MigrationName)
+    requires:
+      vars: [NAME]
+    cmds:
+      - task: api:migration:create
+        vars: { NAME: "{{.NAME}}" }
+
+  migration:run:
+    desc: Run pending migrations for the active DB
+    cmds:
+      - task: api:migration:run
+
+  migration:revert:
+    desc: Revert the last migration for the active DB
+    cmds:
+      - task: api:migration:revert
+
+  migration:show:
+    desc: Show migration status for the active DB
+    cmds:
+      - task: api:migration:show

--- a/api/MIGRATIONS.md
+++ b/api/MIGRATIONS.md
@@ -1,0 +1,132 @@
+# Database Migrations
+
+lya supports 5 databases (PostgreSQL, MySQL, MariaDB, MongoDB, SQLite). Each database has its own migration directory because TypeORM generates DB-specific SQL.
+
+## Directory Structure
+
+```
+src/migrations/
+  postgres/    # PostgreSQL migrations
+  mysql/       # MySQL migrations
+  mariadb/     # MariaDB migrations
+  mongodb/     # MongoDB migrations (hand-written, see below)
+  sqlite/      # SQLite migrations
+```
+
+## Quick Reference
+
+| Task | npm script | Taskfile (via Docker) |
+|------|-----------|----------------------|
+| Generate migration (SQL DBs) | `pnpm migration:generate src/migrations/<db>/Name` | `task migration:generate NAME=Name` |
+| Create empty migration (MongoDB) | `pnpm migration:create src/migrations/mongodb/Name` | `task migration:create NAME=Name` |
+| Run pending migrations | `pnpm migration:run` | `task migration:run` |
+| Revert last migration | `pnpm migration:revert` | `task migration:revert` |
+| Show migration status | `pnpm migration:show` | `task migration:show` |
+
+All commands read the active database from `.env.database` (set via `task set-db DB=<type>` or `scripts/set-db-env.sh`).
+
+## Generating Migrations (SQL Databases)
+
+Use `migration:generate` for PostgreSQL, MySQL, MariaDB, and SQLite. TypeORM compares your entities to the current database schema and generates the necessary SQL.
+
+```bash
+# Inside the API container:
+pnpm migration:generate src/migrations/postgres/AddProjectsTable
+
+# Or from the host via Taskfile:
+task migration:generate NAME=AddProjectsTable
+```
+
+The Taskfile automatically places the migration in the correct directory based on the active database.
+
+### Important: Schema Must Exist First
+
+`migration:generate` diffs entities against the **current database schema**. If the database was created with `synchronize: true` (development default), the schema is already up to date and TypeORM will report "No changes found." To generate the initial migration:
+
+1. Drop the database (or use a fresh one)
+2. Run `pnpm migration:generate src/migrations/<db>/InitialSchema`
+
+## Creating Migrations (MongoDB)
+
+MongoDB is schema-less — `migration:generate` cannot work. Use `migration:create` to scaffold an empty migration, then write the `up`/`down` methods manually.
+
+```bash
+pnpm migration:create src/migrations/mongodb/CreateIndexes
+```
+
+MongoDB migrations typically manage indexes:
+
+```typescript
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateIndexes1234567890 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`db.user.createIndex({ email: 1 }, { unique: true, name: "IDX_user_email" })`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`db.user.dropIndex("IDX_user_email")`)
+  }
+}
+```
+
+## Running Migrations
+
+```bash
+# Run all pending migrations
+pnpm migration:run
+
+# Check which migrations have been applied
+pnpm migration:show
+
+# Revert the last applied migration
+pnpm migration:revert
+```
+
+In **production**, migrations run automatically on application startup (`migrationsRun: true`). In **development**, `synchronize: true` handles schema changes automatically — you don't need to run migrations manually unless testing the migration workflow.
+
+## Multi-DB Workflow
+
+When adding a new entity or modifying a column, you need a migration for each database:
+
+1. Switch to each DB, generate/create the migration:
+   ```bash
+   task up:postgres
+   task migration:generate NAME=AddLocalesTable
+
+   task up:mysql
+   task migration:generate NAME=AddLocalesTable
+
+   task up:mariadb
+   task migration:generate NAME=AddLocalesTable
+
+   task up:sqlite
+   task migration:generate NAME=AddLocalesTable
+
+   # MongoDB: create + hand-write
+   task up:mongodb
+   task migration:create NAME=AddLocalesIndexes
+   # Then edit the generated file manually
+   ```
+
+2. Alternatively, use TypeORM's Schema API (`Table`, `TableColumn`, `TableIndex`) in migrations for a more portable approach — see the initial migrations in each directory for examples.
+
+## DB-Specific Notes
+
+| Database | Notes |
+|----------|-------|
+| **PostgreSQL** | Full migration support. Uses `SERIAL` for auto-increment, `timestamp` for dates. |
+| **MySQL** | Uses `int AUTO_INCREMENT`, `datetime(6)` for dates. Requires `length` on varchar columns. |
+| **MariaDB** | Very similar to MySQL. Keep separate directories — they can diverge on advanced features (JSON, CHECK constraints). |
+| **SQLite** | Limited `ALTER TABLE` — TypeORM works around this by recreating tables. Migrations may be slower for large tables. |
+| **MongoDB** | Schema-less. Only index management via migrations. Always use `migration:create`, never `migration:generate`. |
+
+## CI / Automation
+
+Set `LYA_DB_TYPE` and the corresponding connection variables, then run:
+
+```bash
+pnpm migration:run
+```
+
+In production Docker images, migrations run automatically on app startup via `migrationsRun: true` in the database configuration.

--- a/api/Taskfile.yml
+++ b/api/Taskfile.yml
@@ -18,3 +18,38 @@ tasks:
     desc: Format the API codebase
     cmds:
       - docker compose exec {{.SERVICE_NAME}} pnpm format
+
+  migration:generate:
+    desc: Generate a migration for the active DB (NAME=MigrationName)
+    requires:
+      vars: [NAME]
+    cmds:
+      - docker compose exec {{.SERVICE_NAME}} pnpm migration:generate src/migrations/{{.DB_TYPE}}/{{.NAME}}
+    vars:
+      DB_TYPE:
+        sh: grep LYA_DB_TYPE .env.database | cut -d= -f2
+
+  migration:create:
+    desc: Create an empty migration for the active DB (NAME=MigrationName)
+    requires:
+      vars: [NAME]
+    cmds:
+      - docker compose exec {{.SERVICE_NAME}} pnpm migration:create src/migrations/{{.DB_TYPE}}/{{.NAME}}
+    vars:
+      DB_TYPE:
+        sh: grep LYA_DB_TYPE .env.database | cut -d= -f2
+
+  migration:run:
+    desc: Run pending migrations for the active DB
+    cmds:
+      - docker compose exec {{.SERVICE_NAME}} pnpm migration:run
+
+  migration:revert:
+    desc: Revert the last migration for the active DB
+    cmds:
+      - docker compose exec {{.SERVICE_NAME}} pnpm migration:revert
+
+  migration:show:
+    desc: Show migration status for the active DB
+    cmds:
+      - docker compose exec {{.SERVICE_NAME}} pnpm migration:show

--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,13 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/jest/bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "TS_NODE_PROJECT=tsconfig.migration.json typeorm-ts-node-commonjs -d src/config/data-source.ts",
+    "migration:generate": "pnpm typeorm migration:generate",
+    "migration:create": "pnpm typeorm migration:create",
+    "migration:run": "pnpm typeorm migration:run",
+    "migration:revert": "pnpm typeorm migration:revert",
+    "migration:show": "pnpm typeorm migration:show"
   },
   "engines": {
     "pnpm": ">=10.0.0",

--- a/api/src/config/data-source.ts
+++ b/api/src/config/data-source.ts
@@ -1,0 +1,24 @@
+/**
+ * Standalone DataSource configuration for TypeORM CLI.
+ *
+ * Used by: typeorm-ts-node-commonjs -d src/config/data-source.ts
+ *
+ * IMPORTANT: Do NOT add direct entity imports to this file.
+ * Entities are discovered via glob patterns in buildDataSourceOptions().
+ * The dotenv calls below MUST execute before TypeORM resolves entity globs,
+ * because @UnifiedId() reads LYA_DB_TYPE at decoration time.
+ */
+
+// eslint-disable-next-line import/order
+import { config } from 'dotenv'
+
+config()
+config({ path: '.env.database', override: true })
+
+import { DataSource } from 'typeorm'
+import { buildDataSourceOptions } from './database-options'
+import { resolveDatabaseType } from './database-type.enum'
+
+const type = resolveDatabaseType(process.env.LYA_DB_TYPE)
+
+export default new DataSource(buildDataSourceOptions(type))

--- a/api/src/config/database-options.ts
+++ b/api/src/config/database-options.ts
@@ -1,0 +1,52 @@
+import { join } from 'path'
+import { DataSourceOptions } from 'typeorm'
+import { DatabaseType } from './database-type.enum'
+
+export function buildDataSourceOptions(type: DatabaseType): DataSourceOptions {
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  const commonConfig = {
+    entities: [join(__dirname, '..', '**', '*.entity.{ts,js}')],
+    migrations: [join(__dirname, '..', 'migrations', type, '*.{ts,js}')],
+    synchronize: !isProduction,
+    migrationsRun: isProduction,
+    logging: !isProduction,
+  }
+
+  switch (type) {
+    case DatabaseType.MYSQL:
+    case DatabaseType.MARIADB:
+      return {
+        ...commonConfig,
+        type: type,
+        host: process.env.LYA_DB_HOST || type,
+        port: parseInt(process.env.LYA_DB_PORT, 10) || 3306,
+        username: process.env.LYA_DB_USERNAME || 'root',
+        password: process.env.LYA_DB_PASSWORD || 'password',
+        database: process.env.LYA_DB_NAME || 'lya',
+      }
+    case DatabaseType.POSTGRES:
+      return {
+        ...commonConfig,
+        type: DatabaseType.POSTGRES,
+        host: process.env.LYA_DB_HOST || 'postgres',
+        port: parseInt(process.env.LYA_DB_PORT, 10) || 5432,
+        username: process.env.LYA_DB_USERNAME || 'postgres',
+        password: process.env.LYA_DB_PASSWORD || 'postgres',
+        database: process.env.LYA_DB_NAME || 'lya',
+      }
+    case DatabaseType.MONGODB:
+      return {
+        ...commonConfig,
+        type: DatabaseType.MONGODB,
+        url: process.env.LYA_DB_URL || 'mongodb://localhost:27017/lya',
+      }
+    case DatabaseType.SQLITE:
+    default:
+      return {
+        ...commonConfig,
+        type: DatabaseType.SQLITE,
+        database: process.env.LYA_DB_FILE || 'lya.sqlite',
+      }
+  }
+}

--- a/api/src/config/database.config.ts
+++ b/api/src/config/database.config.ts
@@ -1,51 +1,9 @@
-import { join } from 'path'
 import { registerAs } from '@nestjs/config'
 import { TypeOrmModuleOptions } from '@nestjs/typeorm'
-import { DatabaseType, resolveDatabaseType } from './database-type.enum'
+import { buildDataSourceOptions } from './database-options'
+import { resolveDatabaseType } from './database-type.enum'
 
 export default registerAs('database', (): TypeOrmModuleOptions => {
   const type = resolveDatabaseType(process.env.LYA_DB_TYPE)
-
-  const commonConfig = {
-    entities: [join(__dirname, '..', '**', '*.entity.{ts,js}')],
-    synchronize: process.env.NODE_ENV !== 'production', // Use migrations in production!
-    logging: process.env.NODE_ENV !== 'production',
-  }
-
-  switch (type) {
-    case DatabaseType.MYSQL:
-    case DatabaseType.MARIADB:
-      return {
-        ...commonConfig,
-        type: type,
-        host: process.env.LYA_DB_HOST || type,
-        port: parseInt(process.env.LYA_DB_PORT, 10) || 3306,
-        username: process.env.LYA_DB_USERNAME || 'root',
-        password: process.env.LYA_DB_PASSWORD || 'password',
-        database: process.env.LYA_DB_NAME || 'lya',
-      }
-    case DatabaseType.POSTGRES:
-      return {
-        ...commonConfig,
-        type: DatabaseType.POSTGRES,
-        host: process.env.LYA_DB_HOST || 'postgres',
-        port: parseInt(process.env.LYA_DB_PORT, 10) || 5432,
-        username: process.env.LYA_DB_USERNAME || 'postgres',
-        password: process.env.LYA_DB_PASSWORD || 'postgres',
-        database: process.env.LYA_DB_NAME || 'lya',
-      }
-    case DatabaseType.MONGODB:
-      return {
-        ...commonConfig,
-        type: DatabaseType.MONGODB,
-        url: process.env.LYA_DB_URL || 'mongodb://localhost:27017/lya',
-      }
-    case DatabaseType.SQLITE:
-    default:
-      return {
-        ...commonConfig,
-        type: DatabaseType.SQLITE,
-        database: process.env.LYA_DB_FILE || 'lya.sqlite',
-      }
-  }
+  return buildDataSourceOptions(type) as TypeOrmModuleOptions
 })

--- a/api/src/migrations/mariadb/1742252400000-InitialSchema.ts
+++ b/api/src/migrations/mariadb/1742252400000-InitialSchema.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm'
+
+export class InitialSchema1742252400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            length: '255',
+            isUnique: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+            onUpdate: 'CURRENT_TIMESTAMP(6)',
+          },
+        ],
+      }),
+      true
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user')
+  }
+}

--- a/api/src/migrations/mongodb/1742252400000-InitialIndexes.ts
+++ b/api/src/migrations/mongodb/1742252400000-InitialIndexes.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * MongoDB is schema-less — this migration only manages indexes.
+ *
+ * Use `migration:create` (not `migration:generate`) for MongoDB migrations,
+ * then write the up/down methods manually using QueryRunner methods like:
+ *   - queryRunner.query() with MongoDB commands
+ *   - queryRunner.createCollectionIndex()
+ *   - queryRunner.dropCollectionIndex()
+ */
+export class InitialIndexes1742252400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`db.user.createIndex({ email: 1 }, { unique: true, name: "IDX_user_email" })`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`db.user.dropIndex("IDX_user_email")`)
+  }
+}

--- a/api/src/migrations/mysql/1742252400000-InitialSchema.ts
+++ b/api/src/migrations/mysql/1742252400000-InitialSchema.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm'
+
+export class InitialSchema1742252400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            length: '255',
+            isUnique: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+            onUpdate: 'CURRENT_TIMESTAMP(6)',
+          },
+        ],
+      }),
+      true
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user')
+  }
+}

--- a/api/src/migrations/postgres/1742252400000-InitialSchema.ts
+++ b/api/src/migrations/postgres/1742252400000-InitialSchema.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm'
+
+export class InitialSchema1742252400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            isUnique: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user')
+  }
+}

--- a/api/src/migrations/sqlite/1742252400000-InitialSchema.ts
+++ b/api/src/migrations/sqlite/1742252400000-InitialSchema.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm'
+
+export class InitialSchema1742252400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user',
+        columns: [
+          {
+            name: 'id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            isUnique: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user')
+  }
+}

--- a/api/tsconfig.migration.json
+++ b/api/tsconfig.migration.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
Closes #19

## Summary

- **Per-DB migration directories** (`src/migrations/{postgres,mysql,mariadb,mongodb,sqlite}/`) — each database gets its own migrations since TypeORM generates DB-specific SQL; MongoDB migrations are hand-written (schema-less)
- **Shared `buildDataSourceOptions()`** extracted from `database.config.ts` into `database-options.ts`, used by both the NestJS runtime config and the new standalone DataSource for the TypeORM CLI
- **Standalone `data-source.ts`** with proper dotenv loading order (required because `@UnifiedId()` reads `LYA_DB_TYPE` at decoration time)
- **`tsconfig.migration.json`** — CommonJS module override for TypeORM CLI compatibility with the project's `nodenext` resolution
- **Initial schema migrations** for all 5 databases (creates the `user` table)
- **`migrationsRun: true` in production** — app auto-runs pending migrations on startup; `synchronize: true` remains active in development
- **npm scripts** — `migration:generate`, `migration:create`, `migration:run`, `migration:revert`, `migration:show`
- **Taskfile tasks** — `task migration:generate NAME=Foo`, `task migration:run`, etc. (run inside Docker container)
- **`api/MIGRATIONS.md`** — full documentation covering SQL vs MongoDB workflow, per-DB notes, CI usage

## Test plan

- [ ] Start a DB stack (`task up:postgres` or `task up:sqlite`) and run `task migration:run` — migrations should apply and create the `migrations` tracking table
- [ ] Run `task migration:show` — should list `InitialSchema` as applied
- [ ] Run `task migration:revert` — should undo the migration
- [ ] Run `pnpm lint` in `api/` — passes cleanly
- [ ] Run `pnpm test` in `api/` — all 30 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)